### PR TITLE
Expand on blob usage in HTML widget and move it to the dedicated section

### DIFF
--- a/docs/user_manual/managing_data_source/create_layers.rst
+++ b/docs/user_manual/managing_data_source/create_layers.rst
@@ -90,15 +90,6 @@ These options can be found under the :guilabel:`Advanced Options`
 together with the :guilabel:`Layer identifier` (short human readable
 name of the layer) and the :guilabel:`Layer description`.
 
-.. tip:: **Binary (BLOB) fields**
-
-  If you choose :guilabel:`Binary (BLOB)` data :guilabel:`Type` a drop down
-  menu will allow you to save current binary contents of the field out to a 
-  disk based file, clear contents of a BLOB filed or embed binary contents 
-  by picking a file from your system. QGIS stores binary fields contents as
-  QByteArray values, so this allows for plugins and scripts to utilise binary
-  fields, such as extracting their contents.  
-
 Further management of GeoPackage layers can be done with the
 :ref:`DB Manager <dbmanager>`.
 

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2231,6 +2231,32 @@ The drag and drop designer offers a number of widgets that are not connected to 
 They can be used to enhance the appearance of the form or to display dynamically calculated values.
 
 * :guilabel:`HTML Widget`: embeds an HTML page, the HTML source may contain the result of dynamically calculated expressions.
+
+  HTML widgets can be used for example to display images stored as BLOB in a field
+  (let's call it ``photo``):
+
+  #. In the ``Drag-and-drop designer`` mode, add a :guilabel:`HTML Widget`
+     to your :guilabel:`Form Layout`.
+  #. Double-click on the :guilabel:`HTML Widget` to configure it.
+  #. Change the default :guilabel:`Title` or hide it.
+  #. Press the |expression| button and enter the following QGIS expression:
+
+     .. code-block::
+
+       '<img src= "data:image/png;base64,' || to_base64("photo") || '">'
+
+     Ensure that you replace *photo* with your own BLOB field name.
+     The above expression creates a string with HTML image tag in which the BLOB file is encoded.
+  #. Apply the dialog and then press the |symbologyAdd| button.
+  #. QGIS automatically applies HTML formatting and functions to evaluate your expression,
+     resulting in following code:
+
+     .. code-block:: HTML
+
+       <script>document.write(expression.evaluate("'<img src=\"data:image/png;base64,' || to_base64(\"photo\") || '\">'"));</script>
+
+     A preview of your image is displayed on the right.
+
 * :guilabel:`QML Widget`: embeds a QML page, the QML source may contain the result of dynamically calculated expressions.
 * :guilabel:`Text Widget`: displays a text widget which supports basic HTML markup
   and may contain the result of dynamically calculated expressions.
@@ -2435,9 +2461,16 @@ Based on the field type, QGIS automatically determines and assigns a default
 widget type to it. You can then replace the widget with any other compatible
 with the field type. The available widgets are:
 
-* **Binary (BLOB)**: Available only for binary fields, it offers a lable showing
-  whether the BLOB field is empty or not. If the filed is not empty the content 
-  size will be displayed.
+* **Binary (BLOB)**: Available only for binary fields, it displays by default a label
+  with the size of the embedded data, if not empty.
+  A drop-down button next to the label allows to:
+
+  * :guilabel:`Embed file`, replacing or filling the field
+  * :guilabel:`Clear contents`, removing any data in the field
+  * :guilabel:`Save contents to file`, exporting the data as a file on disk
+
+  It is also possible to preview the embedded binary file in the field,
+  if combined in a drag-and-drop form with e.g. a :ref:`QML or HTML widget <other_widgets>`.
 * **Checkbox**: Displays a checkbox whose state defines the value to insert.
 * **Classification**: Only available when a :ref:`categorized symbology
   <categorized_renderer>` is applied to the layer, displays a combo box with
@@ -2507,21 +2540,6 @@ with the field type. The available widgets are:
    directory as the :file:`.qgs` project file or below, paths are converted to
    relative paths. This increases portability of a :file:`.qgs` project with
    multimedia information attached.
-
-.. tip:: **Display photo stored as a BLOB**
-
-   To display photo stored as BLOB in GeoPackage or PostgreSQL use 
-   :guilabel:`HTML Widget`. Go to :menuselection:`Layer
-   properties --> Attributes Form`, than switch to ``Drag-and-drop designer``
-   and add an :guilabel:`HTML Widget` to your :guilabel:`Form Layout`. Double-click
-   on the :guilabel:`HTML Widget` to configure it. Change the default Title (or choose
-   to hide it), than select BLOB filed from the drop-down menu and press the 
-   |symbologyAdd| button and you will get default HTML to display your field:
-   ``<script>document.write(expression.evaluate("\"photo\""));</script>``, now you
-   have to replace this default expression with this one:
-   ``<script>document.write(expression.evaluate(" '<img src=' || 
-   '\"data:image/png;base64,' || to_base64(\"photo\") || '\">' "))</script>``. Ensure
-   that you replace *photo* with your own BLOB field name.
 
 
 .. index:: Jointure, Join layers


### PR DESCRIPTION
Expose Blob widget drop-down features

@selmaVH1 I have some concerns with the way PR 8507 is handled so here some suggestion for review/discussion, and here exposed my concerns:

* I don't think there is any particular reason to explain binary field behavior in gpkg. This is a field type available also with PG, memory layer, and probably ESRI geodatafile or some other DB. A dedicated section would be a better option and this is what the [supported data and formats](https://docs.qgis.org/testing/en/docs/user_manual/managing_data_source/supported_data.html) was designed for but finally not where I put it
* I finally exposed it while explaining the widget type because IMHO at the end, the information was more about the widget than the binary file format itself
* Instead of using tip which should be used for specific and somehow hidden features, here we are describing how to use a HTML widget so better show it as part of the item's description. And for readability I suggest using numbered list and simplified a bit the code sample used (_and tried to explain what was going on_).

Hope that clarifies and looking forward to your ideas.

